### PR TITLE
:lipstick: Finished styling move component

### DIFF
--- a/src/components/Movie/styles.js
+++ b/src/components/Movie/styles.js
@@ -17,6 +17,14 @@ export default makeStyles((theme) => ({
       textDecoration: 'none',
     },
   },
+  image: {
+    borderRadius: '20px',
+    height: '300px',
+    marginBottom: '10px',
+    '&:hover': {
+      transform: 'scale(1.05)',
+    },
+  },
   title: {
     color: theme.palette.text.primary,
     textOverflow: 'ellipsis',


### PR DESCRIPTION
Added some styling so the whole poster can be seen properly, create space around the poster and give a more obvious visual indicator to help users see which poster they've hovered over.