### PR TITLE
:bug: corrected the redLogo/blueLogo

### DIFF
--- a/src/components/Sidebar/Sidebar.jsx
+++ b/src/components/Sidebar/Sidebar.jsx
@@ -28,8 +28,8 @@ const demoCategories = [
   { label: 'Western', value: 'western' },
 ];
 
-const redLogo = 'https://fontmeme.com/permalink/210930/8531c658a743debe1e1aa1a2fc82006e.png';
-const blueLogo = 'https://fontmeme.com/permalink/210930/6854ae5c7f76597cf8680e48a2c8a50a.png';
+const blueLogo = 'https://fontmeme.com/permalink/210930/8531c658a743debe1e1aa1a2fc82006e.png';
+const redLogo = 'https://fontmeme.com/permalink/210930/6854ae5c7f76597cf8680e48a2c8a50a.png';
 
 const Sidebar = ({ setMobileOpen }) => {
   const classes = useStyles();
@@ -40,7 +40,7 @@ const Sidebar = ({ setMobileOpen }) => {
       <Link to="/" className={classes.imageLink}>
         <img
           className={classes.image}
-          src={theme.palette.mode === 'light' ? redLogo : blueLogo}
+          src={theme.palette.mode === 'light' ? blueLogo : redLogo}
           alt="Filmpire Logo"
         />
       </Link>


### PR DESCRIPTION
closes #18 

The `redLogo' variable point to the red logo now. And the 'blueLogo' points to the blue logo.

The reference to these variables has been adjusted to ensure the correct logo is shown with its corresponding light/dark theme. `blueLogo` for light mode, and `redLogo` for dark mode.