### PR TITLE
Users can now logout

### DIFF
--- a/src/components/Profile/Profile.jsx
+++ b/src/components/Profile/Profile.jsx
@@ -7,7 +7,11 @@ import { userSelector } from '../../features/auth';
 const Profile = () => {
   const { user } = useSelector(userSelector);
 
-  console.log('Profile');
+  const logout = () => {
+    localStorage.clear();
+
+    window.location.href = '/';
+  };
 
   return (
     <Box>


### PR DESCRIPTION
Closes #31 

Added a logout button to the profile page.
When the logout button is clicked, local storage is cleared, so we are no longer holding any session or user data.
The user is then redirected to the root '/' path of the App.