### PR TITLE
Users can now see title, release year and tagline

### DIFF
--- a/src/components/MovieInformation/MovieInformation.jsx
+++ b/src/components/MovieInformation/MovieInformation.jsx
@@ -38,6 +38,14 @@ const MovieInformation = () => {
           alt={data?.title}
         />
       </Grid>
+      <Grid item container direction="column" lg={7}>
+        <Typography variant="h3" align="center" gutterBottom>
+          {data?.title} ({(data.release_date.split('-')[0])})
+        </Typography>
+        <Typography variant="h5" align="center" gutterBottom>
+          {data?.tagline}
+        </Typography>
+      </Grid>
     </Grid>
   );
 };

--- a/src/components/MovieInformation/styles.js
+++ b/src/components/MovieInformation/styles.js
@@ -17,7 +17,6 @@ export default makeStyles((theme) => ({
     [theme.breakpoints.down('md')]: {
       margin: '0 auto',
       width: '50%',
-      // height: '350px',
     },
     [theme.breakpoints.down('sm')]: {
       margin: '0 auto',


### PR DESCRIPTION
Removed a redundant style.
In addition to the poster - users can now also see the title, release year in parenthesis, and the tagline for each movie, in the movie information page - if the info exists. 

A guard ensure that the page does not error if some of the details are missing. E.g. If a movie has no tagline, then the page will still load with all the data we do have on the movie. 