### PR TITLE
Now only showing actors pictures when there is a picture to show

### DIFF
--- a/src/components/MovieInformation/MovieInformation.jsx
+++ b/src/components/MovieInformation/MovieInformation.jsx
@@ -85,6 +85,7 @@ const MovieInformation = () => {
         </Typography>
         <Grid item container spacing={2}>
           {data && data.credits.cast.map((character, i) => (
+            character.profile_path && (
             <Grid
               key={i}
               item
@@ -100,6 +101,7 @@ const MovieInformation = () => {
                 alt={character.name}
               />
             </Grid>
+            )
           ))}
         </Grid>
       </Grid>


### PR DESCRIPTION
Closes #40 

Added a guard to check if there is a profile picture available for each actor in the cast, only displaying a photo for the ones that do. This prevents the Movie Details page from displaying long lists of actors, with many 'broken' images showing only alt text.