### PR TITLE
Feature/movie details

### DIFF
--- a/src/components/MovieInformation/MovieInformation.jsx
+++ b/src/components/MovieInformation/MovieInformation.jsx
@@ -89,7 +89,7 @@ const MovieInformation = () => {
             <Grid
               key={i}
               item
-              sx={4}
+              xs={4}
               md={2}
               component={Link}
               to={`/actors/${character.id}`}

--- a/src/components/MovieInformation/MovieInformation.jsx
+++ b/src/components/MovieInformation/MovieInformation.jsx
@@ -100,6 +100,7 @@ const MovieInformation = () => {
                 src={`https://image.tmdb.org/t/p/w500/${character.profile_path}`}
                 alt={character.name}
               />
+              <Typography color="textPrimary">{character?.name}</Typography>
             </Grid>
             )
           ))}


### PR DESCRIPTION
Closes #42 
It was a small typo in my responsive styles for small screen sizes that was causing the issue. The styles responsible for ensuring everything looks look on small devices was not being implemented due to the typo. Now it's fixed, long actor's names will wrap onto the next line as needed to ensure they don't push adjacent profiles out of their column, leaving unsightly gaps.