### PR TITLE
Users always see full rows of movies regardless of device size

### DIFF
--- a/src/components/Movies/Movies.jsx
+++ b/src/components/Movies/Movies.jsx
@@ -9,6 +9,9 @@ const Movies = () => {
   const [page, setPage] = useState(1);
   const { genreIdOrCategoryName, searchQuery } = useSelector((state) => state.currentGenreOrCategory);
   const { data, error, isFetching } = useGetMoviesQuery({ genreIdOrCategoryName, page, searchQuery });
+  const lg = useMediaQuery((theme) => theme.breakpoints.only('lg'));
+
+  const numberOfMovies = lg ? 16 : 18;
 
   if (isFetching) {
     return (
@@ -34,7 +37,7 @@ const Movies = () => {
 
   return (
     <div>
-      <MovieList movies={data} />
+      <MovieList movies={data} numberOfMovies={numberOfMovies} />
       <Pagination currentPage={page} setPage={setPage} totalPages={data.total_pages} />
     </div>
   );


### PR DESCRIPTION
Closes #55 
We check what size of screen is being used by a given device and load an appropriate number of movies to ensure the rows are always full and do not leave gaps.