### PR TITLE
:recycle: There's always min 1 language so no check needed

### DIFF
--- a/src/components/MovieInformation/MovieInformation.jsx
+++ b/src/components/MovieInformation/MovieInformation.jsx
@@ -82,7 +82,7 @@ const MovieInformation = () => {
             </Typography>
           </Box>
           <Typography variant="h6" align="center" gutterBottom>
-            {data?.runtime}min {data?.spoken_languages.length > 0 ? `/ Language: ${data.spoken_languages[0].name}` : ''}
+            {data?.runtime}min {`/ Language: ${data.spoken_languages[0].name}`}
           </Typography>
         </Grid>
         <Grid item className={classes.genresContainer}>


### PR DESCRIPTION
Having looked into the TMDB API further, I know there is always at least one spoken language for every film. Therefore, it is unnecessary in this case to write code that checks there is at least one, and to display an empty string if there are none.