### PR TITLE
Mobile sidebar now behaves as expected

### DIFF
--- a/src/components/Sidebar/Sidebar.jsx
+++ b/src/components/Sidebar/Sidebar.jsx
@@ -26,6 +26,10 @@ const Sidebar = ({ setMobileOpen }) => {
   const { data, isFetching } = useGetGenresQuery();
   const dispatch = useDispatch();
 
+  useEffect(() => {
+    setMobileOpen(false);
+  }, [genreIdOrCategoryName]);
+
   return (
     <>
       <Link to="/" className={classes.imageLink}>


### PR DESCRIPTION
Closes #81 

When a user using the mobile layout makes a choice on the sidebar, it now collapses out of the way. This is more intuitive and user-friendly.